### PR TITLE
Lisa joonealuse märkuse ja viitamise näide

### DIFF
--- a/135d_EesnimiPerekonnanimi.tex
+++ b/135d_EesnimiPerekonnanimi.tex
@@ -213,6 +213,8 @@ Erinevate viitamisstiilide näidised: \parencite[333]{test0}
 
 \parencite{test11}
 
+Joonealune märkus\footnote{Täiendav selgitus}, viide\footnote{Nimeseadus (RT I, 22.12.2018, 15) \textsection{}6 lõige 1, punkt 1.}.
+
 \addchap{Kokkuvõte}
 
 Kokkuvõttes sõnastatakse eesmärgi täitmine ja antakse vastus sissejuhatuses püsitatud uurimisküsimustele.


### PR DESCRIPTION
Nagu selgub, siis ka seda kasutatakse.

Seadusele / määrusele viitamine on kahtlane, sest seda kasutatud allikate loetelus olema ei peaks, samuti on selle vormistus pisut imelik, nii et jätsin selle tavalise `footnote`'iga. Kui kasutatud allikate loetelust kuidagi see ära saada ([mis näib tüütu](https://tex.stackexchange.com/a/557008)), oleks ilmselt võimalik see siiski ka kuidagi reference'ina vormistada.